### PR TITLE
ci: use npm install instead of npm ci

### DIFF
--- a/.github/actions/build_node/entrypoint.sh
+++ b/.github/actions/build_node/entrypoint.sh
@@ -23,7 +23,7 @@ echo "**************** Copying assets files to build directory ****************"
 cp -R ../build/ .
 
 echo "**************** Installing ****************"
-npm ci
+npm i
 
 echo "**************** Building ****************"
 npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: '18.x'
-      - run: npm ci
+      - run: npm i
       - run: npm run build
       - run: cp -r icons lib/build/svg
       - uses: actions/upload-artifact@master


### PR DESCRIPTION
There are only yarn lockfiles in the repo. Yarn is used in the CI pipeline, but not in any of the publish or release pipelines where instead npm fills that role. For now, we follow the same approach as upstream.