### PR TITLE
Fix the height adaption in the angular based Octicons

### DIFF
--- a/.changeset/wise-kiwis-confess.md
+++ b/.changeset/wise-kiwis-confess.md
@@ -1,0 +1,5 @@
+---
+'@openproject/octicons': patch
+---
+
+Fix height adaption for angular based octicons

--- a/lib/octicons_angular/src/helpers.ts
+++ b/lib/octicons_angular/src/helpers.ts
@@ -1,4 +1,4 @@
-export type SVGSize = 'xsmall' |'small'|'medium'|'large';
+export type SVGSize = 'xsmall'|'small'|'medium'|'large';
 
 export interface SVGData {
  [key: string]: {
@@ -26,8 +26,7 @@ export function toDOMString(data:SVGData, size:SVGSize = 'medium', extraAttribut
   const { width, paths } = data[naturalHeight.toString()];
   const elWidth =  height * (width / naturalHeight);
   return `<svg
-    height="${height}px"
-    width="${elWidth}px"
+    viewBox="0 0 ${elWidth} ${naturalHeight}"
     ${Object.keys(extraAttributes).reduce((total, attr) => `${total} ${attr}="${extraAttributes[attr]}"`, '')}
   >
     ${paths.map(p => `<path d="${p}"></path>`)}

--- a/lib/octicons_angular/src/octicon-component-base.ts
+++ b/lib/octicons_angular/src/octicon-component-base.ts
@@ -34,10 +34,13 @@ export class OpOcticonComponentBase {
       display: 'inline-block',
       'user-select': 'none',
       'vertical-align': this.verticalAlign,
-      overflow: 'visible'
+      overflow: 'visible',
+      height: `${this.height}px`,
+      width: `${this.width}px`
     };
   };
-  @HostBinding('attr.viewBox') get viewBox() {
+  @HostBinding('attr.viewBox')
+  get viewBox() {
     return `0 0 ${this.naturalWidth} ${this.naturalHeight}`;
   }
 
@@ -45,7 +48,6 @@ export class OpOcticonComponentBase {
     return closestNaturalHeight(Object.keys(this.SVGData), this.height)
   }
 
-  @HostBinding('attr.height')
   get height() {
     return sizeMap[this.size];
   }
@@ -54,7 +56,6 @@ export class OpOcticonComponentBase {
     return this.SVGData[this.naturalHeight].width;
   }
 
-  @HostBinding('attr.width')
   get width() {
      return this.height * (this.naturalWidth / this.naturalHeight);
   }


### PR DESCRIPTION
Previuosly, the height was set as attribute on the SVG, but that had no effect on the scaling. Instead, the `viewBox` is set and the height is set as style attribute