### PR TITLE
Fix build process

### DIFF
--- a/.github/actions/build_angular/entrypoint.sh
+++ b/.github/actions/build_angular/entrypoint.sh
@@ -21,7 +21,7 @@ echo "**************** Copying assets files to build directory ****************"
 cp -R ../build/ .
 
 echo "**************** Installing ****************"
-npm ci
+npm ci --legacy-peer-deps
 
 echo "**************** Building ****************"
 npm run build


### PR DESCRIPTION
fix: use --legacy-peer-deps for Angular build to resolve TypeScript 6.x peer conflict

@angular/build@21.x requires typescript >=5.9 <6.0, but the project uses TypeScript 6.0.3. Angular 22 (currently in beta) will support TypeScript 6.x.
