### PR TITLE
fix: downgrade TypeScript to ~5.9.0 for Angular compiler compatibility

### DIFF
--- a/lib/octicons_angular/package-lock.json
+++ b/lib/octicons_angular/package-lock.json
@@ -30,7 +30,7 @@
         "ng-packagr": "^21.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
-        "typescript": "~6.0.3",
+        "typescript": "~5.9.0",
         "typescript-eslint": "8.58.2",
         "vitest": "^4.0.15"
       },
@@ -11340,9 +11340,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/lib/octicons_angular/package.json
+++ b/lib/octicons_angular/package.json
@@ -41,7 +41,7 @@
     "ng-packagr": "^21.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "typescript": "~6.0.3",
+    "typescript": "~5.9.0",
     "typescript-eslint": "8.58.2",
     "vitest": "^4.0.15"
   }


### PR DESCRIPTION
Angular compiler performs a hard version check and rejects TypeScript >=6.0.0. Angular 22 (currently in beta) will support TypeScript 6.x.
